### PR TITLE
修正#1

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,7 +5,6 @@
 @import "modules/index";
 @import "modules/new";
 @import "modules/show";
-@import "modules/devise/new";
 @import "modules/devise/login";
 @import "modules/tweet";
 @import "modules/comment";

--- a/app/assets/stylesheets/modules/new.scss
+++ b/app/assets/stylesheets/modules/new.scss
@@ -27,7 +27,7 @@
           position: absolute;
           top: 0;
           left: 0;
-          opacity: 0;
+          display: none;
         }
         .fa-camera-retro {
           color: #19448e;

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,5 +1,5 @@
 class Tweet < ApplicationRecord
-  belongs_to :user
-  has_many :comments
+  belongs_to :user, optional: true
+  has_many :comments, foreign_key: "tweet_id", dependent: :destroy
   mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :tweets
-  has_many :comments
+  has_many :tweets, foreign_key: :user_id, dependent: :destroy
+  has_many :comments, foreign_key: :user_id, dependent: :destroy
   mount_uploader :avatar, ImageUploader
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -26,7 +26,7 @@
           = f.password_field :password_confirmation, autocomplete: "new-password", class: 'main__devise--form__mask-field'
         .main__devise--form__mask
           %p Choice your Avatar!
-          .main__devise--form__mask-pic
+          = f.label :avatar, class: 'main__devise--form__mask-pic' do
             = f.file_field :avatar, class: 'hidden'
             = fa_icon 'grin-beam'
         = f.submit "Sign up", class: 'main__devise--form__submit'

--- a/app/views/tweets/new.html.haml
+++ b/app/views/tweets/new.html.haml
@@ -4,7 +4,7 @@
       .main__new-form__top
         = f.text_area :text, class: 'text-form'
       .main__new-form__bottom
-        .main__new-form__bottom-image
+        = f.label :image, class: 'main__new-form__bottom-image' do
           = f.file_field :image, class: 'hidden'
           = fa_icon 'camera-retro 5x'
         = f.submit 'Send Tweet', class: 'main__new-form__bottom-btn'


### PR DESCRIPTION
アバター登録とツイート投稿のfile_fieldをopacity: 0;ではなくlabelを追加しdispay: none;に変更
ツイートを削除する際にコメントがあると削除できないバグをアソシエーションの追加により修正
不要ファイルの削除